### PR TITLE
adds objc_show method for Objective-C compatibility

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -488,6 +488,24 @@ extension DropDown {
 //MARK: - Actions
 
 extension DropDown {
+    
+    /**
+     An Objective-C alias for the show() method which converts the returned tuple into an NSDictionary.
+     
+     - returns: An NSDictionary with a value for the "canBeDisplayed" Bool, and possibly for the "offScreenHeight" Optional(CGFloat).
+     */
+    @objc(show)
+    public func objc_show() -> NSDictionary {
+        let (canBeDisplayed, offScreenHeight) = show()
+        
+        var info = [NSObject : AnyObject]()
+        info["canBeDisplayed"] = canBeDisplayed
+        if let offScreenHeight = offScreenHeight {
+            info["offScreenHeight"] = offScreenHeight
+        }
+        
+        return NSDictionary(dictionary: info)
+    }
 	
 	/**
 	Shows the drop down if enough height.


### PR DESCRIPTION
Resolves issue #9 

Hey Kevin! Thanks so much for contributing this library to open source. It's very well written and easy to use. In the process of including it in a project written primarily in Objective-C, I ended up writing the `objc_show` method that you had described in issue #9 and it seems to be working just fine so far (though I haven't been making use of the values returned by the `show()` method).

Cheers!
~Mark